### PR TITLE
Fix Next.js config and extension permission

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -7,7 +7,8 @@
     "storage",
     "activeTab",
     "scripting",
-    "tabs"
+    "tabs",
+    "contextMenus"
   ],
   "host_permissions": [
     "<all_urls>"

--- a/website/next.config.js
+++ b/website/next.config.js
@@ -1,8 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {
-  experimental: {
-    appDir: true,
-  },
-}
+const nextConfig = {}
 
 module.exports = nextConfig


### PR DESCRIPTION
## Summary
- remove deprecated `experimental.appDir` from Next.js config
- add `contextMenus` permission so extension background service worker loads

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68a7c97808848331b8a7b9b430a0ea68